### PR TITLE
Fix bookmark counter element

### DIFF
--- a/index.html
+++ b/index.html
@@ -5071,22 +5071,13 @@ function toggleBookmark(candidateId) {
 
 // Update bookmark counter (FIXED VERSION)
 function updateBookmarkCounter() {
-    // Update both possible elements
-    const headerText = document.getElementById('savedCandidatesHeaderText');
     const savedCount = document.getElementById('savedCount');
     const count = savedCandidates.length;
-    
-    // Update the span in the header button
+
     if (savedCount) {
         savedCount.textContent = count.toString();
     }
-    
-    // Keep the old one for backward compatibility
-    if (headerText) {
-        headerText.textContent = count === 0 ? '0 saved' : 
-                                 count === 1 ? '1 saved' : 
-                                 `${count} saved`;
-    }
+
     console.log('Bookmarks updated:', savedCandidates.length);
 }
 


### PR DESCRIPTION
## Summary
- remove obsolete header text handling
- rely on `savedCount` span when updating bookmark counter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f8572c108832889116dabb4aabb50